### PR TITLE
Removing deprecation warning for Rspec

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -1,6 +1,6 @@
-= Dry Rspec is Fun!
+= Dry RSpec is Fun!
 
-This gem contains a lot of macros for rails specific purposes. This will only work for Rails 3 above and Rspec 2.0 above. A couple of examples:
+This gem contains a lot of macros for rails specific purposes. This will only work for Rails 3 above and RSpec 2.0 above. A couple of examples:
 
 
     describe User do

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ begin
   require 'jeweler'
   Jeweler::Tasks.new do |gem|
     gem.name = "rspec-rails-matchers"
-    gem.summary = %Q{Rspec 2.0 only rails matchers}
+    gem.summary = %Q{RSpec 2.0 only rails matchers}
     gem.description = %Q{Helps you write rspec with rails for fun}
     gem.email = "cyx@sinefunc.com"
     gem.homepage = "http://github.com/sinefunc/rspec-rails-matchers"

--- a/lib/rspec-rails-matchers.rb
+++ b/lib/rspec-rails-matchers.rb
@@ -3,7 +3,7 @@ require 'rspec/matchers'
 
 $LOAD_PATH.unshift(File.expand_path('../', __FILE__))
 
-module RspecRailsMatchers
+module RSpecRailsMatchers
   autoload :Message,      'rspec_rails_matchers/message'
   autoload :Validations,  'rspec_rails_matchers/validations'
   autoload :Associations, 'rspec_rails_matchers/associations'
@@ -11,9 +11,9 @@ module RspecRailsMatchers
   autoload :Sugar,        'rspec_rails_matchers/sugar'
 end
 
-Rspec.configure do |c|
-  c.include RspecRailsMatchers::Validations
-  c.include RspecRailsMatchers::Associations
-  c.include RspecRailsMatchers::Behavior
-  c.include RspecRailsMatchers::Sugar
+RSpec.configure do |c|
+  c.include RSpecRailsMatchers::Validations
+  c.include RSpecRailsMatchers::Associations
+  c.include RSpecRailsMatchers::Behavior
+  c.include RSpecRailsMatchers::Sugar
 end

--- a/lib/rspec_rails_matchers/associations.rb
+++ b/lib/rspec_rails_matchers/associations.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     autoload :Helpers,             'rspec_rails_matchers/associations/helpers'
     autoload :HaveMany,            'rspec_rails_matchers/associations/have_many'

--- a/lib/rspec_rails_matchers/associations/belong_to.rb
+++ b/lib/rspec_rails_matchers/associations/belong_to.rb
@@ -1,16 +1,16 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     module BelongTo
       def belong_to(association)
-        Rspec::Matchers::Matcher.new :belong_to, association do |_association_|
-          extend RspecRailsMatchers::Associations::Helpers
+        RSpec::Matchers::Matcher.new :belong_to, association do |_association_|
+          extend RSpecRailsMatchers::Associations::Helpers
 
           match do |model|
             associations(model, :belongs_to).any? { |a| a == _association_ }
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected  => [ "%s to belong to %s", model, _association_ ],
               :actual    => [ "%s belongs to %s", model, associations(model, :belongs_to) ]
             )

--- a/lib/rspec_rails_matchers/associations/have_and_belong_to_many.rb
+++ b/lib/rspec_rails_matchers/associations/have_and_belong_to_many.rb
@@ -1,16 +1,16 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     module HaveAndBelongToMany
       def have_and_belong_to_many(association)
-        Rspec::Matchers::Matcher.new :have_and_belong_to_many, association do |_association_|
-          extend RspecRailsMatchers::Associations::Helpers
+        RSpec::Matchers::Matcher.new :have_and_belong_to_many, association do |_association_|
+          extend RSpecRailsMatchers::Associations::Helpers
 
           match do |model|
             associations(model, :has_and_belongs_to_many).any? { |a| a == _association_ }
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => [ "%s to have and belong to %s", model, _association_ ],
               :actual   => [ "%s has and belongs to %s", model, associations(model, :has_and_belongs_to_many) ]
             )

--- a/lib/rspec_rails_matchers/associations/have_many.rb
+++ b/lib/rspec_rails_matchers/associations/have_many.rb
@@ -1,16 +1,16 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     module HaveMany
       def have_many(association)
-        Rspec::Matchers::Matcher.new :have_many, association do |_association_|
-          extend RspecRailsMatchers::Associations::Helpers
+        RSpec::Matchers::Matcher.new :have_many, association do |_association_|
+          extend RSpecRailsMatchers::Associations::Helpers
 
           match do |model|
             associations(model, :has_many).any? { |a| a == _association_ }
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => [ "%s to have have many %s", model, _association_ ],
               :actual   => [ "%s has many %s", model, associations(model, :has_many) ]
             )

--- a/lib/rspec_rails_matchers/associations/have_one.rb
+++ b/lib/rspec_rails_matchers/associations/have_one.rb
@@ -1,16 +1,16 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     module HaveOne
       def have_one(association)
-        Rspec::Matchers::Matcher.new :have_one, association do |_association_|
-          extend RspecRailsMatchers::Associations::Helpers
+        RSpec::Matchers::Matcher.new :have_one, association do |_association_|
+          extend RSpecRailsMatchers::Associations::Helpers
 
           match do |model|
             associations(model, :has_one).any? { |a| a == _association_ }
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => [ "%s to have one %s", model, _association_ ],
               :actual   => [ "%s has one %s", model, associations(model, :has_one) ]
             )

--- a/lib/rspec_rails_matchers/associations/helpers.rb
+++ b/lib/rspec_rails_matchers/associations/helpers.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Associations
     module Helpers
       def associations( model, type )

--- a/lib/rspec_rails_matchers/behavior.rb
+++ b/lib/rspec_rails_matchers/behavior.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Behavior
     autoload :Lint, 'rspec_rails_matchers/behavior/lint'
     

--- a/lib/rspec_rails_matchers/behavior/lint.rb
+++ b/lib/rspec_rails_matchers/behavior/lint.rb
@@ -1,9 +1,9 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Behavior
     module Lint
       share_as :AnActiveModel do
         def be_a_boolean
-          Rspec::Matchers::Matcher.new :be_a_boolean do
+          RSpec::Matchers::Matcher.new :be_a_boolean do
             match do |value|
               [ true, false ].include?( value )
             end

--- a/lib/rspec_rails_matchers/message.rb
+++ b/lib/rspec_rails_matchers/message.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Message
     def self.error( options = {} )
       msg =    %(expected #{transform(options[:expected])})

--- a/lib/rspec_rails_matchers/sugar.rb
+++ b/lib/rspec_rails_matchers/sugar.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Sugar
     def self.included( rspec )
       rspec.extend ClassContextMethods

--- a/lib/rspec_rails_matchers/validations.rb
+++ b/lib/rspec_rails_matchers/validations.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     autoload :PresenceOf,     'rspec_rails_matchers/validations/presence_of'
     autoload :NumericalityOf, 'rspec_rails_matchers/validations/numericality_of'

--- a/lib/rspec_rails_matchers/validations/confirmation_of.rb
+++ b/lib/rspec_rails_matchers/validations/confirmation_of.rb
@@ -1,8 +1,8 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     module ConfirmationOf
       def validate_confirmation_of(attribute)
-        Rspec::Matchers::Matcher.new :validate_confirmation_of, attribute do |_attr_|
+        RSpec::Matchers::Matcher.new :validate_confirmation_of, attribute do |_attr_|
           match do |model|
             if model.respond_to?("#{_attr_}_confirmation=")
               model.send("#{_attr_}=", 'asdf')
@@ -16,7 +16,7 @@ module RspecRailsMatchers
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => [ "%s to validate confirmation of %s", model, _attr_ ]
             )
           end

--- a/lib/rspec_rails_matchers/validations/length_of.rb
+++ b/lib/rspec_rails_matchers/validations/length_of.rb
@@ -1,4 +1,4 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     module LengthOf
       def validate_length_of(attribute, options)
@@ -6,14 +6,14 @@ module RspecRailsMatchers
           
         min, max = min_max_for(options)
         
-        Rspec::Matchers::Matcher.new :validate_length_of, attribute do |_attribute_|
+        RSpec::Matchers::Matcher.new :validate_length_of, attribute do |_attribute_|
           match do |model|
             validates_minimum?(model, min, _attribute_) && 
               validates_maximum?(model, max, _attribute_)
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => 
                 [ "%s to validate length of %s, %s", model, _attribute_, options ]
             )

--- a/lib/rspec_rails_matchers/validations/numericality_of.rb
+++ b/lib/rspec_rails_matchers/validations/numericality_of.rb
@@ -1,8 +1,8 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     module NumericalityOf
       def validate_numericality_of( attribute, options = {} )
-        Rspec::Matchers::Matcher.new :validate_numericality_of, attribute do |_attr_|
+        RSpec::Matchers::Matcher.new :validate_numericality_of, attribute do |_attr_|
           match do |model|
             invalid_on_non_numeric?(model, _attr_) && 
               (options[:allow_blank] == true ? 
@@ -11,7 +11,7 @@ module RspecRailsMatchers
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => 
                 [ "%s to validate numericality of %s, %s", model, _attr_, options ]
             )

--- a/lib/rspec_rails_matchers/validations/presence_of.rb
+++ b/lib/rspec_rails_matchers/validations/presence_of.rb
@@ -1,15 +1,15 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     module PresenceOf
       def validate_presence_of(attribute)
-        Rspec::Matchers::Matcher.new :validate_presence_of, attribute do |_attr_|
+        RSpec::Matchers::Matcher.new :validate_presence_of, attribute do |_attr_|
           match do |model|
             model.send("#{_attr_}=", nil)
             model.invalid? && model.errors[_attr_].any?
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => [ "%s to validate presence of %s", model, _attr_ ]
             )
           end

--- a/lib/rspec_rails_matchers/validations/uniqueness_of.rb
+++ b/lib/rspec_rails_matchers/validations/uniqueness_of.rb
@@ -1,8 +1,8 @@
-module RspecRailsMatchers
+module RSpecRailsMatchers
   module Validations
     module UniquenessOf
       def validate_uniqueness_of(attribute, options = {})
-        Rspec::Matchers::Matcher.new :validate_uniqueness_of, attribute do |_attr_|
+        RSpec::Matchers::Matcher.new :validate_uniqueness_of, attribute do |_attr_|
           match do |model|
             duplicate = create_duplicate_record(model, _attr_, options[:scope])
 
@@ -19,7 +19,7 @@ module RspecRailsMatchers
           end
 
           failure_message_for_should do |model|
-            RspecRailsMatchers::Message.error(
+            RSpecRailsMatchers::Message.error(
               :expected => 
                 [ "%s to validate uniqueness of %s, %s", model, _attr_, options ]
             )

--- a/rspec-rails-matchers.gemspec
+++ b/rspec-rails-matchers.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.require_paths = ["lib"]
   s.rubygems_version = %q{1.3.6}
-  s.summary = %q{Rspec 2.0 only rails matchers}
+  s.summary = %q{RSpec 2.0 only rails matchers}
 
   if s.respond_to? :specification_version then
     current_version = Gem::Specification::CURRENT_SPECIFICATION_VERSION


### PR DESCRIPTION
Hi, the macthers are awesome and I have been using them for months without any problem, but recently updated to RSpec 2.6.0 and started to see a bunch of warnings like:

<pre>
DEPRECATION WARNING: you are using a deprecated constant that will
be removed from a future version of RSpec.

* Rspec is deprecated.
* RSpec is the new top-level module in RSpec-2
***************************************************************
</pre>


The following patch solved the problem for me, so hopefully it would be useful for others.
